### PR TITLE
Remove option -l/--local

### DIFF
--- a/doc/parseargs.1.adoc
+++ b/doc/parseargs.1.adoc
@@ -53,10 +53,6 @@ Behave like recommended by POSIX and stop option processing on first none-option
 *-i, --init-vars*::
 Initialize all variables with '' (empty string), except for counting variables, as they are always initialized with 0.
 
-*-l, --local-vars*::
-Create local variables.
-ONLY SUPPORTED WITH --shell `dash`, `bash`, `ksh` and `zsh`.
-
 *-h, --help-opt*::
 Enable support for --help as script option.
 The calling script must provide the function `show_help` that displays the help text.
@@ -66,7 +62,7 @@ Enable support for --version as script options.
 The calling script must provide the function `show_version` that displays the version text.
 
 *-s, --shell* SHELL::
-Produce code for named shell. Supported: `bash`, `ksh`, `zsh`, `dash` and `sh`.
+Produce code for named shell. Supported: `bash`, `ksh`, `zsh` and `sh`.
 Default: `sh`
 
 *--help*::
@@ -303,12 +299,8 @@ The target shell can be changed with the option `-s` / `--shell`-
 `-s sh`::
 The default.
 It generates code for a POSIX shell.
-Those shells don't support local variables and array variable.
-Due to this the option `-l` / `--local-vars` and `-r` / `--remainder` are not supported.
-
-`-s dash`::
-Very close to a POSIX shell, but supports function-local variables.
-As arrays are not supported, `-r` / `--remainder` is not supported.
+Those shells don't support array variables.
+Due to this the option `-r` / `--remainder` are not supported.
 
 `-s bash`, `-s ksh` and `-s zsh`::
 With this shells all features of Parseargs are supported.

--- a/doc/tutorial.adoc
+++ b/doc/tutorial.adoc
@@ -19,8 +19,8 @@ The first section <<POSIX>> treats all functionality that works in a POSIX compl
 Also _zsh_ is not POSIX compliant (and never wanted to be), the mentioned features should run with it.
 
 The second section <<EXTENDED>> handles those few features that need functionality beyond the POSIX standard.
-Here support for function local variables and arrays is needed.
-The shells _bash_, _ksh_ and _zsh_ provide support for both, while _dash_ only supports function local variables.
+Currently there is only on feature, that requires the support of array variables.
+The shells _bash_, _ksh_ and _zsh_ provide this.
 These shells can be enabled by using the option `-s` / `--shell` with the shell name.
 
 NOTE: When _ksh_ is mentioned in this document, we are talking about _ksh92_ or newer.
@@ -632,33 +632,6 @@ No other actions is performed, independent of other options given on the command
 
 This section describes functionalities, that need additional capabilities beyond those defined by POSIX.
 
-=== Creating Local Variables
-
-IMPORTANT: Only supported with shells `dash`, `bash`, `ksh` or `zsh`.
-
-If Parseargs is called in a shell function, it might be needed to declare the variables as local to that function.
-By using the option `-l` / `--local-vars` the variables are declared as local.
-The following invocation is for the bash shell, but ksh and zsh would produce the same code.
-
-[%nowrap]
-----
-$ parseargs -n example.sh -o 'l#long_output,o=outfile' --shell bash --local-vars -- -o out.file -l
-typeset long_output;
-typeset outfile;
-outfile='out.file';
-long_output='true';
-set --
-----
-
-As it is not supported for a plain sh shell, and error message is printed:
-
-[%nowrap]
-----
-$ parseargs -n example.sh -o 'l#long_output,o=outfile' --shell sh --local-vars -- -o out.file -l
-parseargs: Shell sh does not support local variables, so option -l/--local-vars is not supported
-exit 1
-----
-
 === Separating Arguments behind a `--`
 
 IMPORTANT: Only supported with shells `bash`, `ksh` or `zsh`.
@@ -698,14 +671,10 @@ Parseargs supports generating code for different shells. The following shells ar
 `--shell=sh` (the default)::
 With this setting, code for a POSIX compliant shell is generated.
 This should work with any POSIX compliant shell and with _zsh_.
-Function-local variables (`-l` / `--local-vars`) and `-r` / `--remainder` are not supported.
-
-`--shell=dash`::
-The _dash_ shell is POSIX compliant, but additionally supports function-local variables (using the `local` keyword).
-Code generated for _dash_ also works for _bash_ and _ksh_.
+The option `-r` / `--remainder` is not supported.
 
 `--shell=bash`, `--shell=ksh` and `--shell=zsh`::
-This shells support all features of Parseargs, including function-local variables and arrays.
+This shells support all features of Parseargs.
 The code generated is (as of today) identical, except for array initialization, which is different in _ksh_.
 
 

--- a/script-test/_test.shinc
+++ b/script-test/_test.shinc
@@ -150,30 +150,14 @@ test_pa_code()
     fi
 }
 
-
-#
-# Check whether shell supports function local variables.
-# Check by testing for typeset or local command.
-# If PARSEARGS_SHELL = 'sh' always return false
-#
-shell_supports_local_vars()
-{
-    if [ -z "$PARSEARGS_SHELL" ] || [ "$PARSEARGS_SHELL" = "sh" ]; then
-        return 1
-    fi
-    # Typeset & local are undefined in pure sh. Also 'fake_var' is not used.
-    # shellcheck disable=SC3043,SC3044,SC2034
-    typeset fake_var >/dev/null 2>&1 || local fake_var >/dev/null 2>&1
-}
-
 #
 # Whether shell supports arrays.
 # Check by testing for typeset -a command.
-# If PARSEARGS_SHELL = 'sh' or 'dash' always return false
+# If PARSEARGS_SHELL = 'sh' always return false
 #
 shell_supports_arrays()
 {
-    if [ -z "$PARSEARGS_SHELL" ] || [ "$PARSEARGS_SHELL" = "dash" ] || [ "$PARSEARGS_SHELL" = "sh" ]; then
+    if [ -z "$PARSEARGS_SHELL" ] || [ "$PARSEARGS_SHELL" = "sh" ]; then
         return 1
     fi
     # Typeset is undefined in pure sh. Also 'fake_array' is not used.

--- a/script-test/run.sh
+++ b/script-test/run.sh
@@ -82,16 +82,13 @@ get_supported_shell_dialects()
 
     case $bn_sh in
         bash*)
-            echo "bash dash"
+            echo "bash"
             ;;
         ksh*|mksh*)
-            echo "ksh dash"
+            echo "ksh"
             ;;
         zsh*)
-            echo "zsh dash"
-            ;;
-        dash*)
-            echo "dash"
+            echo "zsh"
             ;;
         *)
             # Default: no native dialect


### PR DESCRIPTION
Calling parseargs within a function and keeping the variables local to the function can be achieved with 'typeset' or 'local' key words. No need to handle this in parseargs.

With this also the special support for dash shell is removed, as the difference between sh and dash is just the 'local' keyword.