### PR TITLE
Refactor script option handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,8 +71,8 @@ Some additional tools are needed for building and testing Parseargs.
 This tool is in an early state and there are areas that need further
 improvements
 
-* Gracefully handle arguments with invalid UTF-8 chars. Today it just error exits.
-* To many `clone()` calls -- most likely a general Rust newbie problem.
+* Handle arguments with invalid UTF-8 chars. Today it just error exits.
+* To many Strings where string slices should be used -- most likely a general Rust newbie problem.
 
 
 [Tutorial]: https://rakus.github.io/parseargs/

--- a/doc/tutorial.adoc
+++ b/doc/tutorial.adoc
@@ -465,7 +465,6 @@ $ ./option-cb.sh -v -l -o out.file -vv input
 set_verbosity(1)
 set_long(true)
 set_outfile(out.file)
-set_verbosity(2)
 set_verbosity(3)
 Arguments: input
 
@@ -474,8 +473,9 @@ set_long()
 Arguments: input
 ----
 
-* For counting options, the callback is called multiple times with the current count value.
-* For flags it is called with a value `'true'`. If the option explicitly is set to `false` using `--option=false`, the callback is called with an empty string.
+* For counting options, the callback might be called multiple times with the current count value.
+* For flags it is called with a value `'true'`.
+  If the option explicitly is set to `false` using `--option=false`, the callback is called with an empty string.
 * For assignment options the callback is called with the option argument.
 
 [WARNING]

--- a/src/arg_parser.rs
+++ b/src/arg_parser.rs
@@ -59,7 +59,7 @@ pub struct CmdLineTokenizer {
 }
 
 impl CmdLineTokenizer {
-    pub fn build(args: Vec<String>, posix: bool) -> CmdLineTokenizer {
+    pub fn new(args: Vec<String>, posix: bool) -> CmdLineTokenizer {
         CmdLineTokenizer {
             cmd_line_args: args,
             cmd_line_args_idx: 0,
@@ -187,7 +187,7 @@ mod arg_parser_tests {
         .map(String::from)
         .to_vec();
 
-        let mut pa = CmdLineTokenizer::build(args, false);
+        let mut pa = CmdLineTokenizer::new(args, false);
 
         assert_eq!(Some(CmdLineElement::ShortOption('d')), pa.next());
         assert_eq!(Some(CmdLineElement::ShortOption('o')), pa.next());
@@ -215,7 +215,7 @@ mod arg_parser_tests {
             .map(String::from)
             .to_vec();
 
-        let mut pa = CmdLineTokenizer::build(args, false);
+        let mut pa = CmdLineTokenizer::new(args, false);
 
         assert_eq!(Some(CmdLineElement::Argument("one".to_string())), pa.next());
         assert_eq!(Some(CmdLineElement::ShortOption('d')), pa.next());
@@ -236,7 +236,7 @@ mod arg_parser_tests {
     fn test_combined() {
         let args = ["-dooutfile", "one"].map(String::from).to_vec();
 
-        let mut pa = CmdLineTokenizer::build(args, false);
+        let mut pa = CmdLineTokenizer::new(args, false);
 
         assert_eq!(Some(CmdLineElement::ShortOption('d')), pa.next());
         assert_eq!(Some(CmdLineElement::ShortOption('o')), pa.next());
@@ -249,7 +249,7 @@ mod arg_parser_tests {
     fn test_dash_dash() {
         let args = ["-d", "--", "-o"].map(String::from).to_vec();
 
-        let mut pa = CmdLineTokenizer::build(args, false);
+        let mut pa = CmdLineTokenizer::new(args, false);
 
         assert_eq!(Some(CmdLineElement::ShortOption('d')), pa.next());
         assert_eq!(Some(CmdLineElement::Separator), pa.next());
@@ -263,7 +263,7 @@ mod arg_parser_tests {
             .map(String::from)
             .to_vec();
 
-        let mut pa = CmdLineTokenizer::build(args, true);
+        let mut pa = CmdLineTokenizer::new(args, true);
 
         assert_eq!(Some(CmdLineElement::ShortOption('d')), pa.next());
         assert_eq!(Some(CmdLineElement::Argument("one".to_string())), pa.next());
@@ -286,7 +286,7 @@ mod arg_parser_tests {
             .map(String::from)
             .to_vec();
 
-        let mut pa = CmdLineTokenizer::build(args, true);
+        let mut pa = CmdLineTokenizer::new(args, true);
 
         assert_eq!(Some(CmdLineElement::ShortOption('d')), pa.next());
         assert_eq!(Some(CmdLineElement::Argument("-".to_string())), pa.next());

--- a/src/main.rs
+++ b/src/main.rs
@@ -296,13 +296,11 @@ fn parse_shell_options(
             after_separator = true;
             continue;
         } else if let CmdLineElement::Argument(value) = e {
-            if after_separator && cmd_line_args.remainder.is_some() {
-                if let Some(array) = &cmd_line_args.remainder {
-                    shell_code.push(CodeChunk::AddToArray(
-                        array.clone(),
-                        VarValue::StringValue(value),
-                    ));
-                }
+            if let (true, Some(array)) = (after_separator, &cmd_line_args.remainder) {
+                shell_code.push(CodeChunk::AddToArray(
+                    array.clone(),
+                    VarValue::StringValue(value),
+                ));
             } else if let Some(func) = &cmd_line_args.arg_callback {
                 shell_code.push(CodeChunk::CallFunction(
                     func.clone(),

--- a/src/main.rs
+++ b/src/main.rs
@@ -268,7 +268,7 @@ fn parse_shell_options(
         }
     }
 
-    let mut cl_tok = CmdLineTokenizer::build(script_args, cmd_line_args.posix);
+    let mut cl_tok = CmdLineTokenizer::new(script_args, cmd_line_args.posix);
 
     let mut after_separator = false;
 

--- a/src/opt_def.rs
+++ b/src/opt_def.rs
@@ -6,6 +6,7 @@
  */
 
 use crate::arg_parser::CmdLineElement;
+use std::cell::Cell;
 
 /**
  * Target for a option. Parseargs either assigns a variable or calls
@@ -60,9 +61,9 @@ pub struct OptConfig {
     // Typically used for '--help' etc.
     pub singleton: bool,
     // Runtime: Whether this variable has been set
-    pub assigned: bool,
+    pub assigned: Cell<bool>,
     // Runtime: Count of a counting variable
-    pub count_value: u16,
+    pub count_value: Cell<u16>,
 }
 
 impl OptConfig {
@@ -617,8 +618,8 @@ fn parse_opt_def(ps: &mut ParserSource) -> Result<OptConfig, ParsingError> {
         opt_type: opt_type.0,
         required: opt_attr == Some(OptAttribute::Required),
         singleton: opt_attr == Some(OptAttribute::Singleton),
-        assigned: false,
-        count_value: 0,
+        assigned: Cell::new(false),
+        count_value: Cell::new(0),
     })
 }
 
@@ -698,8 +699,8 @@ mod unit_tests {
             opt_type: OptType::Flag(OptTarget::Variable(String::from("debug"))),
             required: false,
             singleton: false,
-            assigned: false,
-            count_value: 0,
+            assigned: Cell::new(false),
+            count_value: Cell::new(0),
         }
     }
 
@@ -713,8 +714,8 @@ mod unit_tests {
             ),
             required: false,
             singleton: false,
-            assigned: false,
-            count_value: 0,
+            assigned: Cell::new(false),
+            count_value: Cell::new(0),
         }
     }
 
@@ -725,8 +726,8 @@ mod unit_tests {
             opt_type: OptType::Assignment(OptTarget::Variable(String::from("output_file"))),
             required: false,
             singleton: false,
-            assigned: false,
-            count_value: 0,
+            assigned: Cell::new(false),
+            count_value: Cell::new(0),
         }
     }
 
@@ -737,8 +738,8 @@ mod unit_tests {
             opt_type: OptType::Counter(OptTarget::Variable(String::from("verbosity"))),
             required: false,
             singleton: false,
-            assigned: false,
-            count_value: 0,
+            assigned: Cell::new(false),
+            count_value: Cell::new(0),
         }
     }
 


### PR DESCRIPTION
Visible change: If a counter option is given multiple times in a row (e.g. -vvv), only one assignment is generated.