### PR TITLE
Add git hash to version output

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,28 @@
+use std::process::{Command, Output};
+
+fn run_git(args: &[&str]) -> Output {
+    Command::new("git")
+        .args(args)
+        .output()
+        .unwrap_or_else(|_| panic!("failed to execute git {}", args.join(" ")))
+}
+
+// Set rustc environment variable GIT_HASH_STATUS. This contains the short git sha id and, if
+// the workspace is dirty, the string "-dirty" appended.
+fn main() {
+    let output = run_git(&["rev-parse", "--short", "HEAD"]);
+    let short_hash = String::from_utf8(output.stdout).unwrap();
+
+    let output = run_git(&["diff", "--quiet"]);
+    let status = if output.status.code().unwrap_or(1) != 0 {
+        "-dirty"
+    } else {
+        ""
+    };
+
+    let mut git_hash = String::new();
+    git_hash.push_str(short_hash.trim());
+    git_hash.push_str(status);
+
+    println!("cargo:rustc-env=GIT_HASH_STATUS={}", git_hash);
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -23,6 +23,7 @@ use crate::opt_def::{OptConfig, OptTarget, OptType};
 use clap::{CommandFactory, Parser};
 
 const PARSEARGS: &str = env!("CARGO_PKG_NAME");
+const GIT_HASH: &str = env!("GIT_HASH_STATUS");
 
 /**
  * The default shell, if '-s' is not given.
@@ -639,8 +640,9 @@ fn main() {
                 println!("{}", help_str);
                 exit(0);
             } else if c.version {
-                let version_str = CmdLineArgs::command().render_version();
-                print!("{}", version_str);
+                let cmd = CmdLineArgs::command();
+                let version_str = cmd.get_version().unwrap_or("UNKNOWN");
+                println!("parseargs {} ({})", version_str, GIT_HASH);
                 exit(0);
             }
 

--- a/tests/basics.rs
+++ b/tests/basics.rs
@@ -30,7 +30,10 @@ fn test_version() {
         .arg("--version")
         .assert()
         .success()
-        .stdout(format!("parseargs {}\n", VERSION));
+        .stdout(predicate::str::starts_with(format!(
+            "parseargs {} ",
+            VERSION
+        )));
 }
 
 #[test]


### PR DESCRIPTION
Determine git hash and workspace state in build.rs and make the info available as rustc environment variable GIT_HASH_STATUS.